### PR TITLE
Add configurable heal amounts and cooldowns for heart patches

### DIFF
--- a/src/main/java/com/traverse/bhc/common/config/ConfigHandler.java
+++ b/src/main/java/com/traverse/bhc/common/config/ConfigHandler.java
@@ -10,6 +10,18 @@ public class ConfigHandler {
         public final ForgeConfigSpec.ConfigValue<Double> echoShardDropRate;
         public final ForgeConfigSpec.ConfigValue<Double> soulHeartReturnChance;
 
+        // Heart Patch - Heal Amounts
+        public final ForgeConfigSpec.ConfigValue<Integer> redPatchHealAmount;
+        public final ForgeConfigSpec.ConfigValue<Integer> yellowPatchHealAmount;
+        public final ForgeConfigSpec.ConfigValue<Integer> greenPatchHealAmount;
+        public final ForgeConfigSpec.ConfigValue<Integer> bluePatchHealAmount;
+
+        // Heart Patch - Cooldowns (in seconds)
+        public final ForgeConfigSpec.ConfigValue<Integer> redPatchCooldown;
+        public final ForgeConfigSpec.ConfigValue<Integer> yellowPatchCooldown;
+        public final ForgeConfigSpec.ConfigValue<Integer> greenPatchCooldown;
+        public final ForgeConfigSpec.ConfigValue<Integer> bluePatchCooldown;
+
         General(ForgeConfigSpec.Builder builder) {
             builder.push("General");
             heartStackSize = builder
@@ -24,6 +36,36 @@ public class ConfigHandler {
             soulHeartReturnChance = builder
                     .comment("Chance for the Soul Heart to return a Blue Heart Canister after being broken")
                     .define("soulHeartReturnChance", 1.0);
+            builder.pop();
+
+            builder.push("Heart Patches");
+            builder.comment("Heal amounts are in half-hearts (e.g. 2 = 1 full heart)");
+            redPatchHealAmount = builder
+                    .comment("Amount of health restored by the Red Heart Patch")
+                    .define("redPatchHealAmount", 2);
+            yellowPatchHealAmount = builder
+                    .comment("Amount of health restored by the Yellow Heart Patch")
+                    .define("yellowPatchHealAmount", 6);
+            greenPatchHealAmount = builder
+                    .comment("Amount of health restored by the Green Heart Patch")
+                    .define("greenPatchHealAmount", 10);
+            bluePatchHealAmount = builder
+                    .comment("Amount of health restored by the Blue Heart Patch")
+                    .define("bluePatchHealAmount", 20);
+
+            builder.comment("Cooldowns are in seconds");
+            redPatchCooldown = builder
+                    .comment("Cooldown in seconds for the Red Heart Patch")
+                    .define("redPatchCooldown", 5);
+            yellowPatchCooldown = builder
+                    .comment("Cooldown in seconds for the Yellow Heart Patch")
+                    .define("yellowPatchCooldown", 10);
+            greenPatchCooldown = builder
+                    .comment("Cooldown in seconds for the Green Heart Patch")
+                    .define("greenPatchCooldown", 20);
+            bluePatchCooldown = builder
+                    .comment("Cooldown in seconds for the Blue Heart Patch")
+                    .define("bluePatchCooldown", 30);
             builder.pop();
         }
     }

--- a/src/main/java/com/traverse/bhc/common/init/RegistryHandler.java
+++ b/src/main/java/com/traverse/bhc/common/init/RegistryHandler.java
@@ -4,6 +4,7 @@ import com.traverse.bhc.common.BaubleyHeartCanisters;
 import com.traverse.bhc.common.container.BladeOfVitalityContainer;
 import com.traverse.bhc.common.container.HeartAmuletContainer;
 import com.traverse.bhc.common.container.SoulHeartAmuletContainer;
+import com.traverse.bhc.common.config.ConfigHandler;
 import com.traverse.bhc.common.items.*;
 import com.traverse.bhc.common.items.tools.ItemBladeOfVitality;
 import com.traverse.bhc.common.recipes.HeartAmuletRecipe;
@@ -39,10 +40,10 @@ public class RegistryHandler {
     public static final RegistryObject<Item> GREEN_HEART_MELTED = ITEMS.register("green_heart_melted", BaseItem::new);
     public static final RegistryObject<Item> BLUE_HEART_MELTED = ITEMS.register("blue_heart_melted", BaseItem::new);
 
-    public static final RegistryObject<Item> RED_HEART_PATCH = ITEMS.register("red_heart_patch", () -> new ItemHeartPatch(2, 5*20, 20));
-    public static final RegistryObject<Item> YELLOW_HEART_PATCH = ITEMS.register("yellow_heart_patch", () -> new ItemHeartPatch(6, 10*20, 25));
-    public static final RegistryObject<Item> GREEN_HEART_PATCH = ITEMS.register("green_heart_patch", () -> new ItemHeartPatch(10, 20*20, 30));
-    public static final RegistryObject<Item> BLUE_HEART_PATCH = ITEMS.register("blue_heart_patch", () -> new ItemHeartPatch(20, 30*20, 50));
+    public static final RegistryObject<Item> RED_HEART_PATCH = ITEMS.register("red_heart_patch", () -> new ItemHeartPatch(ConfigHandler.general.redPatchHealAmount::get, ConfigHandler.general.redPatchCooldown::get, 20));
+    public static final RegistryObject<Item> YELLOW_HEART_PATCH = ITEMS.register("yellow_heart_patch", () -> new ItemHeartPatch(ConfigHandler.general.yellowPatchHealAmount::get, ConfigHandler.general.yellowPatchCooldown::get, 25));
+    public static final RegistryObject<Item> GREEN_HEART_PATCH = ITEMS.register("green_heart_patch", () -> new ItemHeartPatch(ConfigHandler.general.greenPatchHealAmount::get, ConfigHandler.general.greenPatchCooldown::get, 30));
+    public static final RegistryObject<Item> BLUE_HEART_PATCH = ITEMS.register("blue_heart_patch", () -> new ItemHeartPatch(ConfigHandler.general.bluePatchHealAmount::get, ConfigHandler.general.bluePatchCooldown::get, 50));
 
     public static final RegistryObject<Item> RED_HEART = ITEMS.register("red_heart", () -> new ItemHeart(HeartType.RED));
     public static final RegistryObject<Item> YELLOW_HEART = ITEMS.register("yellow_heart", () -> new ItemHeart(HeartType.YELLOW));

--- a/src/main/java/com/traverse/bhc/common/items/ItemHeartPatch.java
+++ b/src/main/java/com/traverse/bhc/common/items/ItemHeartPatch.java
@@ -17,17 +17,18 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 public class ItemHeartPatch extends BaseItem {
 
-    protected final int amount;
-    protected final int cooldown;
+    protected final Supplier<Integer> amountSupplier;
+    protected final Supplier<Integer> cooldownSupplier;
     protected final int durabilty;
 
-    public ItemHeartPatch(int healAmount, int cooldown, int durabilty) {
+    public ItemHeartPatch(Supplier<Integer> healAmount, Supplier<Integer> cooldownSeconds, int durabilty) {
         super();
-        this.amount = healAmount;
-        this.cooldown = cooldown;
+        this.amountSupplier = healAmount;
+        this.cooldownSupplier = cooldownSeconds;
         this.durabilty = durabilty;
     }
 
@@ -46,8 +47,8 @@ public class ItemHeartPatch extends BaseItem {
         if(!worldIn.isClientSide()) {
             ItemStack stack = playerIn.getItemInHand(handIn);
             worldIn.playSound((Player) null, playerIn.getX(), playerIn.getY(), playerIn.getZ(), SoundEvents.ARMOR_EQUIP_LEATHER, SoundSource.NEUTRAL, 0.5F, 0.4F / (worldIn.getRandom().nextFloat() * 0.4F + 0.8F));
-            playerIn.getCooldowns().addCooldown(stack.getItem(), cooldown);
-            playerIn.heal(amount);
+            playerIn.getCooldowns().addCooldown(stack.getItem(), cooldownSupplier.get() * 20);
+            playerIn.heal(amountSupplier.get());
             if(!playerIn.isCreative()) stack.hurtAndBreak(1, playerIn, (p) -> {
                 p.broadcastBreakEvent(InteractionHand.MAIN_HAND);
             });
@@ -59,7 +60,7 @@ public class ItemHeartPatch extends BaseItem {
     @Override
     public void appendHoverText(ItemStack stack, Level worldIn, List<Component> tooltip, TooltipFlag flagIn) {
         super.appendHoverText(stack, worldIn, tooltip, flagIn);
-        tooltip.add(Component.translatable(Util.makeDescriptionId("tooltip", new ResourceLocation(BaubleyHeartCanisters.MODID, "patch_amount")), amount).setStyle(Style.EMPTY.applyFormat(ChatFormatting.RED)));
+        tooltip.add(Component.translatable(Util.makeDescriptionId("tooltip", new ResourceLocation(BaubleyHeartCanisters.MODID, "patch_amount")), amountSupplier.get()).setStyle(Style.EMPTY.applyFormat(ChatFormatting.RED)));
         tooltip.add(Component.translatable(Util.makeDescriptionId("tooltip", new ResourceLocation(BaubleyHeartCanisters.MODID, "patch_durability")), durabilty - stack.getDamageValue()).setStyle(Style.EMPTY.applyFormat(ChatFormatting.BLUE)));
     }
 


### PR DESCRIPTION
## Summary
- Adds ForgeConfigSpec config values for each heart patch tier's heal amount and cooldown
- Heal amounts configurable in half-hearts, cooldowns in seconds
- Defaults match the previous hardcoded values (no behavior change without config edits)

Tested in SP and SMP